### PR TITLE
Removing add-on 951 Gaspra

### DIFF
--- a/pending_zip_url/db800db4-76b7-45f9-87fb-a2d70c2bb6ac.txt
+++ b/pending_zip_url/db800db4-76b7-45f9-87fb-a2d70c2bb6ac.txt
@@ -1,0 +1,1 @@
+https://celestia.mobi/api/2/helpers/submit-addon-download?blobName=5347A1C8-89F8-4C9E-9B58-02AD3BFC7B55%2Faddon.zip


### PR DESCRIPTION
- Removing the add-ons for Gaspra, Ida, Steins and Apophis. All of them are already included in default Celestia, have had their data recently updated, and their respective default models/textures are of equivalent quality.