### PR TITLE
Update add-on Uranus (1986) and Mu/Nu/Zeta rings

### DIFF
--- a/pending_zip_url/5ad60131-14ad-471c-beec-885cd1ae48b5.txt
+++ b/pending_zip_url/5ad60131-14ad-471c-beec-885cd1ae48b5.txt
@@ -1,0 +1,1 @@
+https://celestia.mobi/api/2/helpers/submit-addon-download?blobName=9FC34748-A21A-492C-B4ED-E3BBCCEEF3D8%2Faddon.zip


### PR DESCRIPTION
- LunarLambert removed after sRGB correction;
- SSC code updated with the latest parameters.