### PR TITLE
Update add-on Galilean Satellites (1995-2036)

### DIFF
--- a/pending_zip_url/e51e0eed-dff6-48c2-b43d-b214d31cdaa2.txt
+++ b/pending_zip_url/e51e0eed-dff6-48c2-b43d-b214d31cdaa2.txt
@@ -1,0 +1,1 @@
+https://celestia.mobi/api/2/helpers/submit-addon-download?blobName=80AEC741-C3EB-4DCA-8CD1-56367B0E2E5E%2Faddon.zip


### PR DESCRIPTION
- General physical parameters updated according to the default;
- Added default specular map for Io; 
- Removed Io's lok-mask; 
- Updated LunarLambert values ​​for Europa, Ganymede and Callisto.