### PR TITLE
Update add-on Meteosat 1 to 7

### DIFF
--- a/pending_zip_url/94e8f689-8987-4b0d-8e03-1a57b8893275.txt
+++ b/pending_zip_url/94e8f689-8987-4b0d-8e03-1a57b8893275.txt
@@ -1,0 +1,1 @@
+https://celestia.mobi/api/2/helpers/submit-addon-download?blobName=02D7A974-D8FF-490D-9F4E-9750D44A2DF9%2Faddon.zip


### PR DESCRIPTION
Corrected the radius of the Meteosat-5 operational component, which was defined differently from its "diffuse" counterpart.