### PR TITLE
Update add-on Abell 65

### DIFF
--- a/pending_zip_url/910f9286-f33a-4587-b103-831ea6eca8e3.txt
+++ b/pending_zip_url/910f9286-f33a-4587-b103-831ea6eca8e3.txt
@@ -1,0 +1,1 @@
+https://celestia.mobi/api/2/helpers/submit-addon-download?blobName=29F858FE-135F-4919-8EE2-65332E842744%2Faddon.zip


### PR DESCRIPTION
- Central star renamed "Abell 65 CS", following the standard for nebulae; 
- Updated Rich Description.