### PR TITLE
Update add-on Venus (1974)

### DIFF
--- a/pending_zip_url/ce3ce327-ce5a-4116-876b-476b9a1e4fd5.txt
+++ b/pending_zip_url/ce3ce327-ce5a-4116-876b-476b9a1e4fd5.txt
@@ -1,0 +1,1 @@
+https://celestia.mobi/api/2/helpers/submit-addon-download?blobName=56442E65-00BF-4F65-8EC3-E8654B69893C%2Faddon.zip


### PR DESCRIPTION
- Since the default atmospheric parameters for various objects (including Venus) have been updated, the SSC code has been modified to alter only the atmosphere texture. This ensures the default parameters are preserved even if future changes are made by the development/content team.
- Add-on (title, description and files) renamed to "Venus (1974)", given that the Mariner 10 flyby took place in Feb 1974, not 1973.