### PR TITLE
Add Betelgeuse replaced Sun addon

### DIFF
--- a/pending_zip_url/e90c3655-e3bc-4483-a075-ea5ae1a32c35.txt
+++ b/pending_zip_url/e90c3655-e3bc-4483-a075-ea5ae1a32c35.txt
@@ -1,0 +1,1 @@
+https://celestia.mobi/api/2/helpers/submit-addon-download?blobName=047779D8-DEC7-4A69-B9B1-980467E9FBC7%2Faddon.zip


### PR DESCRIPTION
This pull request adds the Sun replaced with Betelgeuse add-on to the Celestia Mobile add-on catalog.

The add-on modifies Sol's stellar properties to resemble the red supergiant Betelgeuse (α Orionis).

